### PR TITLE
Add a builtin `RedirectException`

### DIFF
--- a/fps/exceptions.py
+++ b/fps/exceptions.py
@@ -1,0 +1,13 @@
+from fastapi import Request, Response
+from fastapi.responses import RedirectResponse
+
+
+class RedirectException(Exception):
+    def __init__(self, redirect_to: str):
+        self.redirect_to = redirect_to
+
+
+async def _redirect_exception_handler(
+    request: Request, exc: RedirectException
+) -> Response:
+    return RedirectResponse(url=exc.redirect_to)

--- a/fps/main.py
+++ b/fps/main.py
@@ -9,6 +9,7 @@ from starlette.routing import Mount
 
 from fps import hooks
 from fps.config import Config, FPSConfig, create_default_plugin_model
+from fps.exceptions import RedirectException, _redirect_exception_handler
 from fps.hooks import HookType
 from fps.logging import configure_loggers
 from fps.utils import get_pkg_name, get_plugin_name
@@ -45,6 +46,8 @@ def _load_exceptions_handlers(app: FastAPI) -> None:
     pm = _get_pluggin_manager(HookType.EXCEPTION)
 
     grouped_exceptions_handlers = _grouped_hookimpls_results(pm.hook.exception_handler)
+
+    app.add_exception_handler(RedirectException, _redirect_exception_handler)
 
     if grouped_exceptions_handlers:
 

--- a/plugins/helloworld/fps_helloworld/routes.py
+++ b/plugins/helloworld/fps_helloworld/routes.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, Depends
 from fps_helloworld.config import get_config
 from fps_helloworld.exceptions import RedirectException
 
+from fps.exceptions import RedirectException as FpsRedirectException
 from fps.hooks import register_router
 
 r = APIRouter()
@@ -22,8 +23,12 @@ async def root(name: str = "world", config=Depends(get_config)):
 
 @r.get("/wrong_hello")
 async def wrong_hello():
+    raise RedirectException("Wrong place to say hello", "/hello")
 
-    raise RedirectException("Bad place to say hello", "/hello")
+
+@r.get("/bad_hello")
+async def bad_hello():
+    raise FpsRedirectException("/hello")
 
 
 router = register_router(r)

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,4 +23,3 @@ install_requires =
   toml
   fastapi
   pluggy>=1.0,<2.0
-


### PR DESCRIPTION
Description
---

Add a builtin `RedirectException`:
- add it to the app using `add_exception_handler`
- add a demo in `helloworld` plugin

Following ideas drafted by @wolfv in https://github.com/jupyter-server/fps/issues/27#issuecomment-924866705

One can directly use this exception:
```python
from fps.exceptions import RedirectException

@r.get("/bad_hello")
async def bad_hello():
    raise RedirectException("/hello")
```
to redirect, with the minimal logs from the server. Here using `uvicorn`:
```
[I 2021-09-22 17:35:33 uvicorn.access] 127.0.0.1:35760 - "GET /bad_hello HTTP/1.1" 307 Temporary Redirect
```

cc @hbcarlos