### PR TITLE
Handle list delimiters for `disabled_plugins`

### DIFF
--- a/fps/config.py
+++ b/fps/config.py
@@ -5,11 +5,13 @@ from types import ModuleType
 from typing import Dict, List, Tuple, Type
 
 import toml
-from pydantic import BaseModel, create_model
+from pydantic import BaseModel, create_model, validator
 
 import fps
 from fps.errors import ConfigError
 from fps.utils import get_pkg_name, get_plugin_name
+
+logger = logging.getLogger("fps")
 
 
 class PluginModel(BaseModel):
@@ -32,8 +34,14 @@ class FPSConfig(BaseModel):
     # plugins
     disabled_plugins: List[str] = []
 
-
-logger = logging.getLogger("fps")
+    @validator("disabled_plugins")
+    def disabled_plugins_format(cls, plugins):
+        warnings = [p for p in plugins if p.startswith("[") or p.endswith("]")]
+        logger.warning(
+            f"Disabled plugins {warnings} include list delimiter(s), "
+            "it could be due to bad configuration"
+        )
+        return plugins
 
 
 class Config:

--- a/plugins/uvicorn/fps_uvicorn/cli.py
+++ b/plugins/uvicorn/fps_uvicorn/cli.py
@@ -36,7 +36,10 @@ def parse_extra_options(options: List[str]) -> Dict[str, Any]:
                     f"Plugin option must be of the form '<plugin-name>.<option>', got '{key}'"
                 )
             if "," in val:
-                return {key: [v for v in val.split(",")]}
+                if val.startswith("[") and val.endswith("]"):
+                    return {key: [v for v in val[1:-1].split(",")]}
+                else:
+                    return {key: [v for v in val.split(",")]}
             else:
                 return {key: val}
 


### PR DESCRIPTION
Description
---

Check for list delimiters in CLI comma separated values
Warn about possible mistake with disabled plugins names containing list delimiters

```
$ fps-uvicorn --fps.disabled_plugins=[authenticator,contents,kernels,Lab,nbconvert,terminals,yjs
[I 2021-10-13 14:39:11 fps] Loading server configuration
[W 2021-10-13 14:39:11 fps] Disabled plugins ['[authenticator'] include list delimiters, it could be a bad configuration
```

Related to #40 