### PR TITLE
Add `enabled_plugins` config

### DIFF
--- a/fps/config.py
+++ b/fps/config.py
@@ -32,15 +32,17 @@ class FPSConfig(BaseModel):
     description: str = "A fast plugins server"
 
     # plugins
+    enabled_plugins: List[str] = []
     disabled_plugins: List[str] = []
 
-    @validator("disabled_plugins")
-    def disabled_plugins_format(cls, plugins):
+    @validator("enabled_plugins", "disabled_plugins")
+    def plugins_format(cls, plugins):
         warnings = [p for p in plugins if p.startswith("[") or p.endswith("]")]
-        logger.warning(
-            f"Disabled plugins {warnings} include list delimiter(s), "
-            "it could be due to bad configuration"
-        )
+        if warnings:
+            logger.warning(
+                f"Enabled or disabled plugins {warnings} include list delimiter(s), "
+                "it could be due to bad configuration"
+            )
         return plugins
 
 

--- a/fps/main.py
+++ b/fps/main.py
@@ -178,6 +178,10 @@ def _load_routers(app: FastAPI) -> None:
                 plugin_config
                 and not plugin_config.enabled
                 or p_name in Config(FPSConfig).disabled_plugins
+                or (
+                    Config(FPSConfig).enabled_plugins
+                    and p_name not in Config(FPSConfig).enabled_plugins
+                )
             )
             if not routers or disabled:
                 disabled_msg = " (disabled)" if disabled else ""


### PR DESCRIPTION
Description
---

Add capability to set enabled plugins using `fps.enabled_plugins` configuration.
Left empty, all plugins will be loaded to avoid requiring explicit enabling

Closes #40