### PR TITLE
Support whitespaces in list configs

### DIFF
--- a/plugins/uvicorn/fps_uvicorn/cli.py
+++ b/plugins/uvicorn/fps_uvicorn/cli.py
@@ -39,7 +39,7 @@ def parse_extra_options(options: List[str]) -> Dict[str, Any]:
                 if val.startswith("[") and val.endswith("]"):
                     return {key: [v.strip() for v in val[1:-1].split(",")]}
                 else:
-                    return {key: [v for v in val.split(",")]}
+                    return {key: [v.strip() for v in val.split(",")]}
             else:
                 return {key: val}
 


### PR DESCRIPTION
Description
---

Allow whitespaces in list delimited configuration such as `fps-uvicorn --fps.disabled_plugins='[authenticator, contents, kernels, Lab, nbconvert, terminals, yjs]'`.

`fps-uvicorn --fps.disabled_plugins='authenticator, contents, kernels, Lab, nbconvert, terminals, yjs'` is also supported now but not `fps-uvicorn --fps.disabled_plugins=authenticator, contents, kernels, Lab, nbconvert, terminals, yjs`  which is parsed as separate extra arguments.