### PR TITLE
Automated Changelog Entry for 0.0.13 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.0.13
+
+([Full Changelog](https://github.com/jupyter-server/fps/compare/v0.0.12...166041e3346e3fa6773f8d6f48b08dacee785cb5))
+
+### Merged PRs
+
+- Fix exit [#70](https://github.com/jupyter-server/fps/pull/70) ([@davidbrochart](https://github.com/davidbrochart))
+- [pre-commit.ci] pre-commit autoupdate [#69](https://github.com/jupyter-server/fps/pull/69) ([@pre-commit-ci](https://github.com/pre-commit-ci))
+- [pre-commit.ci] pre-commit autoupdate [#68](https://github.com/jupyter-server/fps/pull/68) ([@pre-commit-ci](https://github.com/pre-commit-ci))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/fps/graphs/contributors?from=2022-07-14&to=2022-08-29&type=c))
+
+[@davidbrochart](https://github.com/search?q=repo%3Ajupyter-server%2Ffps+involves%3Adavidbrochart+updated%3A2022-07-14..2022-08-29&type=Issues) | [@pre-commit-ci](https://github.com/search?q=repo%3Ajupyter-server%2Ffps+involves%3Apre-commit-ci+updated%3A2022-07-14..2022-08-29&type=Issues)
+
+<!-- <END NEW CHANGELOG ENTRY> -->
+
 ## 0.0.12
 
 ([Full Changelog](https://github.com/jupyter-server/fps/compare/v0.0.11...724caf852e8952a5e7eb89c604d3d5d6179e4040))
@@ -15,8 +33,6 @@
 ([GitHub contributors page for this release](https://github.com/jupyter-server/fps/graphs/contributors?from=2022-07-14&to=2022-07-14&type=c))
 
 [@davidbrochart](https://github.com/search?q=repo%3Ajupyter-server%2Ffps+involves%3Adavidbrochart+updated%3A2022-07-14..2022-07-14&type=Issues)
-
-<!-- <END NEW CHANGELOG ENTRY> -->
 
 ## 0.0.11
 


### PR DESCRIPTION
Automated Changelog Entry for 0.0.13 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyter-server/fps  |
| Branch  | main  |
| Version Spec | next |
| Since | v0.0.12 |