### PR TITLE
missing default values in cli.main

### DIFF
--- a/src/fps/_cli.py
+++ b/src/fps/_cli.py
@@ -46,11 +46,11 @@ TEST = False
 @click.argument("module", default="")
 def main(
     module: str,
-    config: TextIO | None,
-    show_config: bool,
-    help_all: bool,
-    set_: list[str],
-    backend: str,
+    config: TextIO | None = None,
+    show_config: bool = False,
+    help_all: bool = False,
+    set_: list[str] | None = None,
+    backend: str = "asyncio",
 ):
     global CONFIG
     if config is None:
@@ -69,7 +69,7 @@ def main(
         else:
             for root_module_name in config_dict:
                 break
-    for _set in set_:
+    for _set in set_ or []:
         if "=" not in _set:
             raise click.ClickException(
                 f"No '=' while setting a module parameter: {_set}"


### PR DESCRIPTION
fps 0.1.5 adds required positional arguments `show_config`, `help_all`, and `backend` to `main()`, which means JupyterHub can't launch jupyverse, leading to:

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/runner/work/jupyterhub/jupyterhub/jupyterhub/singleuser/__main__.py", line 4, in <module>
    main()
  File "/home/runner/work/jupyterhub/jupyterhub/jupyterhub/singleuser/app.py", line 103, in main
    return launch()
           ^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.11/x64/lib/python3.11/site-packages/fps_auth_jupyterhub/launch.py", line 10, in launch
    return main.callback(
           ^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.11.11/x64/lib/python3.11/site-packages/jupyverse_api/cli.py", line 91, in main
    fps_main.callback(
TypeError: main() missing 3 required positional arguments: 'show_config', 'help_all', and 'backend'
```