### PR TITLE
Drop `anyioutils`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,7 @@ classifiers = [
 ]
 requires-python = ">= 3.10"
 dependencies = [
-    "anyio",
-    "anyioutils >=0.7.0,<0.8.0",
+    "anyio >=4.14.0,<5.0.0",
     "structlog",
     "exceptiongroup; python_version<'3.11'",
 ]

--- a/src/fps/web/server.py
+++ b/src/fps/web/server.py
@@ -34,7 +34,7 @@ class ServerModule(Module):
             server_task = await tg.start(
                 partial(
                     serve,
-                    app,  # type: ignore[arg-type]
+                    app,  # type: ignore
                     config,
                     shutdown_trigger=self.shutdown_event.wait,
                     mode="asgi",

--- a/src/fps/web/server.py
+++ b/src/fps/web/server.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from functools import partial
 
 from anyio import Event, create_task_group
-from anyioutils import start_task
 from anycorn import Config, serve
 from fastapi import FastAPI
 
@@ -32,7 +31,7 @@ class ServerModule(Module):
         config.websocket_permessage_deflate = self.websocket_permessage_deflate
         config.loglevel = "WARN"
         async with create_task_group() as tg:
-            server_task = start_task(
+            server_task = await tg.start(
                 partial(
                     serve,
                     app,  # type: ignore[arg-type]
@@ -40,13 +39,12 @@ class ServerModule(Module):
                     shutdown_trigger=self.shutdown_event.wait,
                     mode="asgi",
                 ),
-                tg,
+                return_handle=True,
             )
-            await server_task.wait_started()
 
             async def stop():
                 self.shutdown_event.set()
-                await server_task.wait()
+                await server_task
 
             self.add_teardown_callback(stop)
             self.done()


### PR DESCRIPTION
`anyioutils`'s `start_task` is replaced with `anyio`'s task handle that is available in v4.14.0.